### PR TITLE
Fix Docker build failures by using npm workspace build commands

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -33,12 +33,11 @@ WORKDIR /app
 # Copy all source code
 COPY . .
 
-# Copy node_modules from deps stage
+# Copy node_modules from deps stage (includes workspace dependencies)
 COPY --from=deps /app/node_modules ./node_modules
 
-# Build the backend
-WORKDIR /app/apps/backend
-RUN npm run build
+# Build the backend from root directory using npm workspace
+RUN npm run build:backend
 
 # Production dependencies stage
 FROM node:18-slim AS prod-deps

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -3,6 +3,7 @@ import cors from '@fastify/cors';
 import helmet from '@fastify/helmet';
 import jwt from '@fastify/jwt';
 import websocket from '@fastify/websocket';
+import '@fastify/jwt';
 import { createServer } from 'http';
 import { Server } from 'socket.io';
 import dotenv from 'dotenv';

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -24,10 +24,10 @@ COPY . .
 # Copy node_modules from deps stage
 COPY --from=deps /app/node_modules ./node_modules
 
-# Build the frontend
-WORKDIR /app/apps/frontend
+# Build the frontend using npm workspace from root directory
+WORKDIR /app
 ENV NODE_ENV=production NEXT_TELEMETRY_DISABLED=1 DOCKER_BUILD=true
-RUN npm run build
+RUN npm run build:frontend
 
 # Production stage - Ultra lightweight
 FROM node:18-alpine AS runner


### PR DESCRIPTION
- Fix backend Dockerfile to use npm run build:backend from root
- Fix frontend Dockerfile to use npm run build:frontend from root
- Resolves TypeScript compilation errors from missing @fastify/jwt module
- Ensures proper npm workspace dependency resolution in Docker builds